### PR TITLE
Fixed versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,5 +8,3 @@
 [build-system]
 requires = ["pyyaml", "setuptools", "setuptools_scm", "toml", "wheel"]
 build-backend = "setuptools.build_meta"
-
-[tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,9 @@ classifier =
     Programming Language :: Python
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
 
 [options]


### PR DESCRIPTION
- specify all supported Python versions in setup.cfg
- remove "[setuptools_scm]" section from pyproject.toml to make our custom versioning script work again

 On branch 0.5
 Changes to be committed:
	modified:   pyproject.toml
	modified:   setup.cfg